### PR TITLE
Update project structure and enhance MVVM implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -482,3 +482,4 @@ $RECYCLE.BIN/
 
 # Vim temporary swap files
 *.swp
+**/*/coveragereport

--- a/MyCLIWpfApp.Tests/WpfTest.cs
+++ b/MyCLIWpfApp.Tests/WpfTest.cs
@@ -7,7 +7,11 @@ public class WpfTest
 {
     protected const string WindowsApplicationDriverUrl = "http://127.0.0.1:4723";
     static string _ProjectDirectory = Directory.GetParent(Directory.GetCurrentDirectory())?.Parent?.Parent?.FullName ?? "";
+#if RELEASE
     string _PathToTheDemo = _ProjectDirectory + @"\bin\Release\net9.0-windows\MyCLIWpfApp.Wpf.exe";
+#else
+    string _PathToTheDemo = _ProjectDirectory + @"\bin\Debug\net9.0-windows\MyCLIWpfApp.Wpf.exe";
+#endif
     private WindowsDriver<WindowsElement>? _DesktopSession;
 
     [OneTimeSetUp]

--- a/MyCLIWpfApp.Wpf/MainWindow.xaml
+++ b/MyCLIWpfApp.Wpf/MainWindow.xaml
@@ -5,10 +5,14 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:local="clr-namespace:MyCLIWpfApp.Wpf"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    Title="MainWindow"
+    xmlns:vm="clr-namespace:MyCLIWpfApp.Wpf.ViewModels"
+    Title="{Binding Title}"
     Width="800"
     Height="450"
     mc:Ignorable="d">
+    <Window.DataContext>
+        <vm:BaseViewModel />
+    </Window.DataContext>
     <StackPanel Margin="12">
         <TextBlock Text="Enter your name:" />
         <TextBox x:Name="txtName" AutomationProperties.AutomationId="txtName" />

--- a/MyCLIWpfApp.Wpf/MainWindow.xaml.cs
+++ b/MyCLIWpfApp.Wpf/MainWindow.xaml.cs
@@ -1,13 +1,4 @@
-﻿using System.Text;
-using System.Windows;
-using System.Windows.Controls;
-using System.Windows.Data;
-using System.Windows.Documents;
-using System.Windows.Input;
-using System.Windows.Media;
-using System.Windows.Media.Imaging;
-using System.Windows.Navigation;
-using System.Windows.Shapes;
+﻿using System.Windows;
 
 namespace MyCLIWpfApp.Wpf;
 

--- a/MyCLIWpfApp.Wpf/ViewModels/BaseViewModel.cs
+++ b/MyCLIWpfApp.Wpf/ViewModels/BaseViewModel.cs
@@ -1,0 +1,34 @@
+﻿using System.ComponentModel;
+using System.Runtime.CompilerServices;
+
+namespace MyCLIWpfApp.Wpf.ViewModels
+{
+    public class BaseViewModel : INotifyPropertyChanged
+    {
+#if RELEASE
+        public string _Title = "Main Window";
+#else
+        public string _Title = "Main Window QA";
+#endif
+
+        public string? Title
+        {
+            get => _Title;
+            set => SetProperty(ref _Title, value);
+        }
+        public event PropertyChangedEventHandler? PropertyChanged;
+        protected void OnPropertyChanged([CallerMemberName] string propertyName = null)
+        {
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+        }
+        protected bool SetProperty<T>(ref T storage, T value, [CallerMemberName] string propertyName = "")
+        {
+            if (Equals(storage, value))
+                return false;
+
+            storage = value;
+            OnPropertyChanged(propertyName);
+            return true;
+        }
+    }
+}


### PR DESCRIPTION
Update project structure and enhance MVVM implementation

- Updated `.gitignore` to exclude coverage report files.
- Added conditional compilation for `_PathToTheDemo` in `WpfTest.cs`.
- Changed `MainWindow.xaml` to bind `Title` dynamically using `BaseViewModel`.
- Simplified `using` directives in `MainWindow.xaml.cs`.
- Introduced `BaseViewModel` class to support property change notifications.